### PR TITLE
ST3 Restricted begin_edit() and end_edit()

### DIFF
--- a/diff_tabs.py
+++ b/diff_tabs.py
@@ -33,9 +33,7 @@ class DiffTabsCommand(sublime_plugin.WindowCommand):
             v.set_name(os.path.basename(bname) + " -> " + os.path.basename(aname))
             v.set_scratch(True)
             v.set_syntax_file('Packages/Diff/Diff.tmLanguage')
-            edit = v.begin_edit()
-            v.insert(edit, 0, difftxt)
-            v.end_edit(edit)
+            v.run_command('append', {'characters':difftxt})
 
     def is_visible(self, group, index):
         window = self.window


### PR DESCRIPTION
Fixed the error TypeError: begin_edit() missing 2 required positional arguments: 'edit_token' and 'cmd'
Taken from here: [Plugin Porting Guide](https://www.sublimetext.com/docs/3/porting_guide.html)